### PR TITLE
ContentType should fallback to 'application/octet-stream' when guess failed.

### DIFF
--- a/feign-form/src/main/java/feign/form/multipart/AbstractWriter.java
+++ b/feign-form/src/main/java/feign/form/multipart/AbstractWriter.java
@@ -67,10 +67,10 @@ public abstract class AbstractWriter implements Writer {
     String fileContentType = contentType;
     if (fileContentType == null) {
       if (fileName != null) {
-          fileContentType = URLConnection.guessContentTypeFromName(fileName);
+        fileContentType = URLConnection.guessContentTypeFromName(fileName);
       }
       if (fileContentType == null) {
-          fileContentType = "application/octet-stream";
+        fileContentType = "application/octet-stream";
       }
     }
 

--- a/feign-form/src/main/java/feign/form/multipart/AbstractWriter.java
+++ b/feign-form/src/main/java/feign/form/multipart/AbstractWriter.java
@@ -66,9 +66,12 @@ public abstract class AbstractWriter implements Writer {
 
     String fileContentType = contentType;
     if (fileContentType == null) {
-      fileContentType = fileName != null
-                        ? URLConnection.guessContentTypeFromName(fileName)
-                        : "application/octet-stream";
+      if (fileName != null) {
+          fileContentType = URLConnection.guessContentTypeFromName(fileName);
+      }
+      if (fileContentType == null) {
+          fileContentType = "application/octet-stream";
+      }
     }
 
     val string = new StringBuilder()

--- a/feign-form/src/test/java/feign/form/BasicClientTest.java
+++ b/feign-form/src/test/java/feign/form/BasicClientTest.java
@@ -149,4 +149,13 @@ public class BasicClientTest {
     Assert.assertNotNull(response);
     Assert.assertEquals(200, response.status());
   }
+
+  @Test
+  public void testUnknownTypeFile() throws Exception {
+      val path = Paths.get(this.getClass().getClassLoader().getResource("file.abc").toURI());
+      Assert.assertTrue(Files.exists(path));
+
+      val stringResponse = api.uploadUnknownType(path.toFile());
+      Assert.assertEquals("application/octet-stream", stringResponse);
+  }
 }

--- a/feign-form/src/test/java/feign/form/Server.java
+++ b/feign-form/src/test/java/feign/form/Server.java
@@ -167,4 +167,15 @@ public class Server {
                  : I_AM_A_TEAPOT;
     return ResponseEntity.status(status).body(file.getOriginalFilename());
   }
+
+  @PostMapping(
+      path = "/upload/unknown_type",
+      consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<String> uploadUnknownType (@RequestPart("file") MultipartFile file) {
+    val status = file != null
+                 ? OK
+                 : I_AM_A_TEAPOT;
+    return ResponseEntity.status(status).body(file.getContentType());
+  }
 }

--- a/feign-form/src/test/java/feign/form/TestClient.java
+++ b/feign-form/src/test/java/feign/form/TestClient.java
@@ -65,4 +65,8 @@ public interface TestClient {
   @RequestLine("POST /upload/with_json")
   @Headers("Content-Type: multipart/form-data")
   Response uploadWithJson (@Param("dto") Dto dto, @Param("file") File file);
+
+  @RequestLine("POST /upload/unknown_type")
+  @Headers("Content-Type: multipart/form-data")
+  String uploadUnknownType (@Param("file") File file);
 }


### PR DESCRIPTION
**Current behavior**
When upload file like Excel 2007 Worksheet, it has `ContentType = "null"` in Request Body.
```
--1610eed465f
Content-Disposition: form-data; name="file"; filename="test.xlsx"
Content-Type: null
Content-Transfer-Encoding: binary
<!-- XLSX BINARY CONTENT -->
--1610eed465f--
```