### PR TITLE
Fixed spring form encoder for multiple MultipartFile

### DIFF
--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
@@ -108,6 +108,20 @@ public interface Client {
   )
   String upload6Collection (@RequestPart List<MultipartFile> files);
 
+  @RequestMapping(
+          path = "/multipart/upload7",
+          method = POST,
+          consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  String upload7Array (@RequestPart MultipartFile[] files);
+
+  @RequestMapping(
+          path = "/multipart/upload7",
+          method = POST,
+          consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  String upload7Collection (@RequestPart List<MultipartFile> files);
+
   class ClientConfiguration {
 
     @Autowired

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -25,6 +25,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import lombok.SneakyThrows;
@@ -131,6 +132,19 @@ public class Server {
       result = new String(popa1.getBytes()) + new String(popa2.getBytes());
     }
     return ResponseEntity.status(status).body(result);
+  }
+
+  @RequestMapping(
+          path = "/multipart/upload7",
+          method = POST,
+          consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<String> upload7 (@RequestParam("files") MultipartFile[] files) throws Exception {
+    StringBuilder result = new StringBuilder();
+    for (MultipartFile kek: files) {
+      result.append(new String(kek.getBytes()));
+    }
+    return ResponseEntity.ok(result.toString());
   }
 
   @RequestMapping(

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -133,4 +133,24 @@ public class SpringFormEncoderTest {
     val response = client.upload6Collection(list);
     Assert.assertEquals("Hello world", response);
   }
+
+  @Test
+  public void upload7ArrayTest () throws Exception {
+    val file1 = new MockMultipartFile("files", "debug", null, "Hello".getBytes(UTF_8));
+    val file2 = new MockMultipartFile("files", "release", null, " world".getBytes(UTF_8));
+
+    val response = client.upload7Array(new MultipartFile[] { file1, file2 });
+    Assert.assertEquals("Hello world", response);
+  }
+
+  @Test
+  public void upload7CollectionTest () throws Exception {
+    List<MultipartFile> list = asList(
+            new MockMultipartFile("files", "debug", null, "Hello".getBytes(UTF_8)),
+            new MockMultipartFile("files", "release", null, " world".getBytes(UTF_8))
+    );
+
+    val response = client.upload7Collection(list);
+    Assert.assertEquals("Hello world", response);
+  }
 }


### PR DESCRIPTION
If I need to send several files with the same name, only one of them will be sent now. This request resolves this problem in the encoder by grouping files with the same name.
