### PR TITLE
Add support for Enum<?> as Feign client parameters for multipart payload

### DIFF
--- a/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
+++ b/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
@@ -33,6 +33,7 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.form.multipart.ByteArrayWriter;
 import feign.form.multipart.DelegateWriter;
+import feign.form.multipart.EnumWriter;
 import feign.form.multipart.FormDataWriter;
 import feign.form.multipart.ManyFilesWriter;
 import feign.form.multipart.ManyParametersWriter;
@@ -69,6 +70,7 @@ public class MultipartFormContentProcessor implements ContentProcessor {
     addWriter(new ManyFilesWriter());
     addWriter(new SingleParameterWriter());
     addWriter(new ManyParametersWriter());
+    addWriter(new EnumWriter());
     addWriter(new PojoWriter(writers));
 
     defaultPerocessor = new DelegateWriter(delegate);

--- a/feign-form/src/main/java/feign/form/multipart/EnumWriter.java
+++ b/feign-form/src/main/java/feign/form/multipart/EnumWriter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.form.multipart;
+
+import static feign.form.ContentProcessor.CRLF;
+
+import feign.codec.EncodeException;
+import lombok.val;
+
+/**
+ *
+ * @author Andriy Redkp
+ */
+public class EnumWriter extends AbstractWriter {
+
+  @Override
+  public boolean isApplicable (Object value) {
+    return value instanceof Enum;
+  }
+
+  @Override
+  protected void write (Output output, String key, Object value) throws EncodeException {
+    val name = ((Enum<?>) value).name();
+    
+    val string = new StringBuilder()
+        .append("Content-Disposition: form-data; name=\"").append(key).append('"').append(CRLF)
+        .append("Content-Type: text/plain; charset=").append(output.getCharset().name()).append(CRLF)
+        .append(CRLF)
+        .append(name)
+        .toString();
+
+    output.write(string);
+  }
+}

--- a/feign-form/src/test/java/feign/form/BasicClientTest.java
+++ b/feign-form/src/test/java/feign/form/BasicClientTest.java
@@ -82,6 +82,15 @@ public class BasicClientTest {
     val stringResponse = API.upload(path.toFile());
     Assert.assertEquals(Files.size(path), Long.parseLong(stringResponse));
   }
+  
+  @Test
+  public void testUploadContent () throws Exception {
+    val path = Paths.get(Thread.currentThread().getContextClassLoader().getResource("file.txt").toURI());
+    Assert.assertTrue(Files.exists(path));
+
+    val stringResponse = API.upload(ContentType.MULTIPART, path.toFile());
+    Assert.assertEquals(Files.size(path), Long.parseLong(stringResponse));
+  }
 
   @Test
   public void testUploadWithParam () throws Exception {

--- a/feign-form/src/test/java/feign/form/Server.java
+++ b/feign-form/src/test/java/feign/form/Server.java
@@ -98,6 +98,17 @@ public class Server {
     }
     return ResponseEntity.status(status).body(file.getSize());
   }
+  
+  @RequestMapping(path = "/upload/content", method = POST)
+  public ResponseEntity<Long> upload (@RequestParam("content-type") ContentType contentType,  @RequestParam("file") MultipartFile file) {
+    HttpStatus status;
+    if (contentType == null) {
+      status = BAD_REQUEST;
+    } else {
+      status = OK;
+    }
+    return ResponseEntity.status(status).body(file.getSize());
+  }
 
   @RequestMapping(path = "/upload/files", method = POST)
   public ResponseEntity<Long> upload (@RequestParam("files") MultipartFile[] files) {

--- a/feign-form/src/test/java/feign/form/TestClient.java
+++ b/feign-form/src/test/java/feign/form/TestClient.java
@@ -41,6 +41,10 @@ public interface TestClient {
   @Headers("Content-Type: multipart/form-data")
   String upload (@Param("id") Integer id, @Param("public") Boolean isPublic, @Param("file") File file);
 
+  @RequestLine("POST /upload/content")
+  @Headers("Content-Type: multipart/form-data")
+  String upload (@Param("content-type") ContentType contentType, @Param("file") File file);
+  
   @RequestLine("POST /upload")
   @Headers("Content-Type: multipart/form-data")
   String upload (@Param("file") File file);


### PR DESCRIPTION
Hey guys,

We've run into an issue recently when multipart endpoint uses Java's enumeration (`Enum<?>`) for some of the parameter. The `MultipartFormContentProcessor` does recognize the `Enum` as the POJO and tries to convert it into the `Map`, ending up with the empty one. As such, all `Enum<?>` parameters are not being included into the request.

The fix is simple (add `EnumWriter`), the test cases is provided, easy to reproduce.
Thank you.

Best Regards,
    Andriy Redko