### PR TITLE
Allow @RequestPart POJOs

### DIFF
--- a/feign-form-spring/pom.xml
+++ b/feign-form-spring/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.1.5.RELEASE</version>
+      <version>5.2.5.RELEASE</version>
       <scope>compile</scope>
     </dependency>
 
@@ -58,13 +58,13 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.1.3.RELEASE</version>
+      <version>2.2.6.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
-      <version>2.1.1.RELEASE</version>
+      <version>2.2.2.RELEASE</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.form.spring;
+
+import static feign.form.ContentProcessor.CRLF;
+import static feign.form.util.PojoUtil.isUserPojo;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
+
+import feign.codec.EncodeException;
+import feign.form.multipart.AbstractWriter;
+import feign.form.multipart.Output;
+
+import lombok.val;
+
+import java.io.IOException;
+
+/**
+ *
+ * @author Darren Foong
+ */
+public abstract class PojoSerializationWriter extends AbstractWriter {
+  @Override
+  public boolean isApplicable(Object object) {
+    return !(object instanceof MultipartFile) && !(object instanceof MultipartFile[]) && isUserPojo(object);
+  }
+
+  @Override
+  public void write (Output output, String key, Object object) throws EncodeException {
+    try {
+      val string = new StringBuilder()
+          .append("Content-Disposition: form-data; name=\"").append(key).append('"')
+          .append(CRLF)
+          .append("Content-Type: ").append(getContentType())
+          .append("; charset=").append(output.getCharset().name())
+          .append(CRLF)
+          .append(CRLF)
+          .append(serialize(object))
+          .toString();
+
+      output.write(string);
+    } catch (IOException e) {
+      throw new EncodeException(e.getMessage());
+    }
+  }
+
+  protected abstract MediaType getContentType();
+
+  protected abstract String serialize(Object object) throws IOException;
+}

--- a/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
@@ -65,6 +65,12 @@ public abstract class PojoSerializationWriter extends AbstractWriter {
   protected abstract String serialize(Object object) throws IOException;
 
   private boolean isUserPojoCollection(Object object) {
+    if (object.getClass().isArray()) {
+      val array = (Object[]) object;
+
+      return array.length > 1 && isUserPojo(array[0]);
+    }
+
     if (!(object instanceof Iterable)) {
       return false;
     }

--- a/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/PojoSerializationWriter.java
@@ -37,7 +37,8 @@ import java.io.IOException;
 public abstract class PojoSerializationWriter extends AbstractWriter {
   @Override
   public boolean isApplicable(Object object) {
-    return !(object instanceof MultipartFile) && !(object instanceof MultipartFile[]) && isUserPojo(object);
+    return !(object instanceof MultipartFile) && !(object instanceof MultipartFile[])
+            && (isUserPojoCollection(object) || isUserPojo(object));
   }
 
   @Override
@@ -62,4 +63,21 @@ public abstract class PojoSerializationWriter extends AbstractWriter {
   protected abstract MediaType getContentType();
 
   protected abstract String serialize(Object object) throws IOException;
+
+  private boolean isUserPojoCollection(Object object) {
+    if (!(object instanceof Iterable)) {
+      return false;
+    }
+
+    val iterable = (Iterable<?>) object;
+    val iterator = iterable.iterator();
+
+    if (iterator.hasNext()) {
+      val next = iterator.next();
+
+      return !(next instanceof MultipartFile) && isUserPojo(next);
+    } else {
+      return false;
+    }
+  }
 }

--- a/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
@@ -59,6 +59,15 @@ public class SpringFormEncoder extends FormEncoder {
     processor.addFirstWriter(new SpringManyMultipartFilesWriter());
   }
 
+  public SpringFormEncoder(PojoSerializationWriter pojoSerializationWriter, Encoder delegate) {
+    super(delegate);
+
+    val processor = (MultipartFormContentProcessor) getContentProcessor(MULTIPART);
+    processor.addFirstWriter(new SpringSingleMultipartFileWriter());
+    processor.addFirstWriter(new SpringManyMultipartFilesWriter());
+    processor.addFirstWriter(pojoSerializationWriter);
+  }
+
   @Override
   public void encode (Object object, Type bodyType, RequestTemplate template) throws EncodeException {
     if (bodyType.equals(MultipartFile[].class)) {

--- a/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
@@ -70,24 +70,9 @@ public class SpringFormEncoder extends FormEncoder {
 
   @Override
   public void encode (Object object, Type bodyType, RequestTemplate template) throws EncodeException {
-    if (bodyType.equals(MultipartFile[].class)) {
-      val files = (MultipartFile[]) object;
-      val data = new HashMap<String, Object>(files.length, 1.F);
-      for (val file : files) {
-        data.put(file.getName(), file);
-      }
-      super.encode(data, MAP_STRING_WILDCARD, template);
-    } else if (bodyType.equals(MultipartFile.class)) {
+    if (bodyType.equals(MultipartFile.class)) {
       val file = (MultipartFile) object;
       val data = singletonMap(file.getName(), object);
-      super.encode(data, MAP_STRING_WILDCARD, template);
-    } else if (isMultipartFileCollection(object)) {
-      val iterable = (Iterable<?>) object;
-      val data = new HashMap<String, Object>();
-      for (val item : iterable) {
-        val file = (MultipartFile) item;
-        data.put(file.getName(), file);
-      }
       super.encode(data, MAP_STRING_WILDCARD, template);
     } else {
       super.encode(object, bodyType, template);

--- a/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
@@ -78,13 +78,4 @@ public class SpringFormEncoder extends FormEncoder {
       super.encode(object, bodyType, template);
     }
   }
-
-  private boolean isMultipartFileCollection (Object object) {
-    if (!(object instanceof Iterable)) {
-      return false;
-    }
-    val iterable = (Iterable<?>) object;
-    val iterator = iterable.iterator();
-    return iterator.hasNext() && iterator.next() instanceof MultipartFile;
-  }
 }

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
@@ -126,6 +126,13 @@ public interface Client {
   )
   String upload8 (@RequestPart("pojo") Pojo pojo, @RequestPart("files") List<MultipartFile> files);
 
+  @RequestMapping(
+      path = "/multipart/upload9",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  String upload9 (@RequestPart("pojos") List<Pojo> pojos, @RequestPart("files") List<MultipartFile> files);
+
   class ClientConfiguration {
 
     @Autowired

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
@@ -131,7 +131,14 @@ public interface Client {
       method = POST,
       consumes = MULTIPART_FORM_DATA_VALUE
   )
-  String upload9 (@RequestPart("pojos") List<Pojo> pojos, @RequestPart("files") List<MultipartFile> files);
+  String upload9Array (@RequestPart("pojos") Pojo[] pojos, @RequestPart("files") List<MultipartFile> files);
+
+  @RequestMapping(
+      path = "/multipart/upload9",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  String upload9Collection (@RequestPart("pojos") List<Pojo> pojos, @RequestPart("files") List<MultipartFile> files);
 
   class ClientConfiguration {
 

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Client.java
@@ -120,9 +120,9 @@ public interface Client {
   String upload7 (@RequestPart("pojo") Pojo pojo);
 
   @RequestMapping(
-          path = "/multipart/upload8",
-          method = POST,
-          consumes = MULTIPART_FORM_DATA_VALUE
+      path = "/multipart/upload8",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
   )
   String upload8 (@RequestPart("pojo") Pojo pojo, @RequestPart("files") List<MultipartFile> files);
 

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Pojo.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Pojo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.form.feign.spring;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = PRIVATE)
+public class Pojo {
+  String field1;
+
+  String field2;
+
+  int field3;
+}

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -162,6 +162,23 @@ public class Server {
   }
 
   @RequestMapping(
+      path = "/multipart/upload9",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<String> upload9 (@RequestPart("pojos") List<Pojo> pojos, @RequestPart("files") List<MultipartFile> files
+  ) throws Exception {
+    val pojo1 = pojos.get(0);
+    val pojo2 = pojos.get(1);
+
+    val result1 = pojo1.getField1() + pojo1.getField2() + pojo1.getField3();
+    val result2 = pojo2.getField1() + pojo2.getField2() + pojo2.getField3();
+    val result3 = new String(files.get(0).getBytes()) + new String(files.get(1).getBytes());
+
+    return ResponseEntity.ok(result1 + result2 + result3);
+  }
+
+  @RequestMapping(
       path = "/multipart/download/{fileId}",
       method = GET,
       produces = MULTIPART_FORM_DATA_VALUE

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -149,9 +149,9 @@ public class Server {
   }
 
   @RequestMapping(
-          path = "/multipart/upload8",
-          method = POST,
-          consumes = MULTIPART_FORM_DATA_VALUE
+      path = "/multipart/upload8",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
   )
   public ResponseEntity<String> upload8 (@RequestPart("pojo") Pojo pojo, @RequestPart("files") List<MultipartFile> files
   ) throws Exception {

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -25,6 +25,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import lombok.SneakyThrows;
@@ -121,9 +122,11 @@ public class Server {
       method = POST,
       consumes = MULTIPART_FORM_DATA_VALUE
   )
-  public ResponseEntity<String> upload6 (@RequestParam("popa1") MultipartFile popa1,
-                                         @RequestParam("popa2") MultipartFile popa2
+  public ResponseEntity<String> upload6 (@RequestPart("files") List<MultipartFile> files
   ) throws Exception {
+    MultipartFile popa1 = files.get(0);
+    MultipartFile popa2 = files.get(1);
+
     HttpStatus status = I_AM_A_TEAPOT;
     String result = "";
     if (popa1 != null && popa2 != null) {
@@ -131,6 +134,31 @@ public class Server {
       result = new String(popa1.getBytes()) + new String(popa2.getBytes());
     }
     return ResponseEntity.status(status).body(result);
+  }
+
+  @RequestMapping(
+      path = "/multipart/upload7",
+      method = POST,
+      consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<String> upload7 (@RequestPart("pojo") Pojo pojo
+  ) throws Exception {
+    val result = pojo.getField1() + pojo.getField2() + pojo.getField3();
+
+    return ResponseEntity.ok(result);
+  }
+
+  @RequestMapping(
+          path = "/multipart/upload8",
+          method = POST,
+          consumes = MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<String> upload8 (@RequestPart("pojo") Pojo pojo, @RequestPart("files") List<MultipartFile> files
+  ) throws Exception {
+    val result1 = pojo.getField1() + pojo.getField2() + pojo.getField3();
+    val result2 = new String(files.get(0).getBytes()) + new String(files.get(1).getBytes());
+
+    return ResponseEntity.ok(result1 + result2);
   }
 
   @RequestMapping(

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -146,7 +146,7 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload6CollectionSameNameTest () throws Exception {
-    val list = asList(
+    List<MultipartFile> list = asList(
         (MultipartFile) new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8)),
         (MultipartFile) new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8))
     );
@@ -179,13 +179,13 @@ public class SpringFormEncoderTest {
   @Test
   public void upload9ArrayTest () throws Exception {
     val pojos = new Pojo[]{
-            new Pojo("Hello", " world", 1),
-            new Pojo("Hello", " world", 2)
+        new Pojo("Hello", " world", 1),
+        new Pojo("Hello", " world", 2)
     };
 
     val list = asList(
-            (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
-            (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
+        (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
+        (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
     );
 
     val response = client.upload9Array(pojos, list);

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -177,7 +177,23 @@ public class SpringFormEncoderTest {
   }
 
   @Test
-  public void upload9Test () throws Exception {
+  public void upload9ArrayTest () throws Exception {
+    val pojos = new Pojo[]{
+            new Pojo("Hello", " world", 1),
+            new Pojo("Hello", " world", 2)
+    };
+
+    List<MultipartFile> list = asList(
+            (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
+            (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
+    );
+
+    val response = client.upload9Array(pojos, list);
+    Assert.assertEquals("Hello world1Hello world2Hello world", response);
+  }
+
+  @Test
+  public void upload9CollectionTest () throws Exception {
     List<Pojo> pojos = asList(
         new Pojo("Hello", " world", 1),
         new Pojo("Hello", " world", 2)
@@ -188,7 +204,7 @@ public class SpringFormEncoderTest {
         (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
     );
 
-    val response = client.upload9(pojos, list);
+    val response = client.upload9Collection(pojos, list);
     Assert.assertEquals("Hello world1Hello world2Hello world", response);
   }
 }

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -21,7 +21,6 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -146,8 +146,8 @@ public class SpringFormEncoderTest {
   @Test
   public void upload6CollectionSameNameTest () throws Exception {
     List<MultipartFile> list = asList(
-            (MultipartFile) new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8)),
-            (MultipartFile) new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8))
+        (MultipartFile) new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8)),
+        (MultipartFile) new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8))
     );
 
     val response = client.upload6Collection(list);

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -126,7 +126,7 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload6CollectionTest () throws Exception {
-    List<MultipartFile> list = asList(
+    val list = asList(
         (MultipartFile) new MockMultipartFile("popa1", "popa1", null, "Hello".getBytes(UTF_8)),
         (MultipartFile) new MockMultipartFile("popa2", "popa2", null, " world".getBytes(UTF_8))
     );
@@ -146,7 +146,7 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload6CollectionSameNameTest () throws Exception {
-    List<MultipartFile> list = asList(
+    val list = asList(
         (MultipartFile) new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8)),
         (MultipartFile) new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8))
     );
@@ -157,7 +157,7 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload7Test () throws Exception {
-    Pojo pojo = new Pojo("Hello", " world", 1);
+    val pojo = new Pojo("Hello", " world", 1);
 
     val response = client.upload7(pojo);
     Assert.assertEquals("Hello world1", response);
@@ -165,9 +165,9 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload8Test () throws Exception {
-    Pojo pojo = new Pojo("Hello", " world", 1);
+    val pojo = new Pojo("Hello", " world", 1);
 
-    List<MultipartFile> list = asList(
+    val list = asList(
         (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
         (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
     );
@@ -183,7 +183,7 @@ public class SpringFormEncoderTest {
             new Pojo("Hello", " world", 2)
     };
 
-    List<MultipartFile> list = asList(
+    val list = asList(
             (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
             (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
     );
@@ -194,12 +194,12 @@ public class SpringFormEncoderTest {
 
   @Test
   public void upload9CollectionTest () throws Exception {
-    List<Pojo> pojos = asList(
+    val pojos = asList(
         new Pojo("Hello", " world", 1),
         new Pojo("Hello", " world", 2)
     );
 
-    List<MultipartFile> list = asList(
+    val list = asList(
         (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
         (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
     );

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -133,4 +133,25 @@ public class SpringFormEncoderTest {
     val response = client.upload6Collection(list);
     Assert.assertEquals("Hello world", response);
   }
+
+  @Test
+  public void upload7Test () throws Exception {
+    Pojo pojo = new Pojo("Hello", " world", 1);
+
+    val response = client.upload7(pojo);
+    Assert.assertEquals("Hello world1", response);
+  }
+
+  @Test
+  public void upload8Test () throws Exception {
+    Pojo pojo = new Pojo("Hello", " world", 1);
+
+    List<MultipartFile> list = asList(
+        (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
+        (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
+    );
+
+    val response = client.upload8(pojo, list);
+    Assert.assertEquals("Hello world1Hello world", response);
+  }
 }

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -21,6 +21,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -173,5 +174,21 @@ public class SpringFormEncoderTest {
 
     val response = client.upload8(pojo, list);
     Assert.assertEquals("Hello world1Hello world", response);
+  }
+
+  @Test
+  public void upload9Test () throws Exception {
+    List<Pojo> pojos = asList(
+        new Pojo("Hello", " world", 1),
+        new Pojo("Hello", " world", 2)
+    );
+
+    List<MultipartFile> list = asList(
+        (MultipartFile) new MockMultipartFile("files", "popa1", null, "Hello".getBytes(UTF_8)),
+        (MultipartFile) new MockMultipartFile("files", "popa2", null, " world".getBytes(UTF_8))
+    );
+
+    val response = client.upload9(pojos, list);
+    Assert.assertEquals("Hello world1Hello world2Hello world", response);
   }
 }

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringFormEncoderTest.java
@@ -135,6 +135,26 @@ public class SpringFormEncoderTest {
   }
 
   @Test
+  public void upload6ArraySameNameTest () throws Exception {
+    val file1 = new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8));
+    val file2 = new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8));
+
+    val response = client.upload6Array(new MultipartFile[] { file1, file2 });
+    Assert.assertEquals("Hello world", response);
+  }
+
+  @Test
+  public void upload6CollectionSameNameTest () throws Exception {
+    List<MultipartFile> list = asList(
+            (MultipartFile) new MockMultipartFile("popa0", "popa1", null, "Hello".getBytes(UTF_8)),
+            (MultipartFile) new MockMultipartFile("popa0", "popa2", null, " world".getBytes(UTF_8))
+    );
+
+    val response = client.upload6Collection(list);
+    Assert.assertEquals("Hello world", response);
+  }
+
+  @Test
   public void upload7Test () throws Exception {
     Pojo pojo = new Pojo("Hello", " world", 1);
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,13 +146,13 @@ limitations under the License.
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.1.3.RELEASE</version>
+      <version>2.2.6.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>2.1.3.RELEASE</version>
+      <version>2.2.6.RELEASE</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
I'm using Spring Cloud OpenFeign, and I have a use case where I need to send *multiple* files *and* POJOs as `multipart/form-data`, for example:

```
@PostMapping("/items")
SomeResponse uploadItems(@RequestPart List<SomePojo> items, @RequestPart List<MultipartFile> itemImages);
```

There was a recent fix in spring-cloud/spring-cloud-openfeign#258 that allowed the use of multiple `@RequestPart`s, but it was only for `MultipartFile` and boxed primitive types. This PR builds on the abovementioned PR by:

- Upgrading the Spring dependencies in `pom.xml` to enjoy the benefits of the abovementioned PR
- Add a `PojoSerializationWriter` that can serialize POJOs to some string; in the unit tests I use Jackson to serialize as JSON
- Update `SpringFormEncoder` to (optionally) use `PojoSerializationWriter`
- Simplify `SpringFormEncoder.encode()` by removing code that is unnecessary due to spring-cloud/spring-cloud-openfeign#258 already doing the conversion to Map (except for one if-clause for `@ResponseBody MultipartFile`)
- Update existing unit tests because spring-cloud/spring-cloud-openfeign#258 requires `@RequestPart`s to have a `value`
- Add new unit tests to test upload of various types of `@RequestPart`s: collections, arrays, `MultipartFile`, etc.

With this PR, pull requests #71 and #74 are also no longer necessary.