### PR TITLE
Scenario with multiple file in array.

### DIFF
--- a/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
@@ -20,6 +20,7 @@ import static feign.form.ContentType.MULTIPART;
 import static java.util.Collections.singletonMap;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import feign.RequestTemplate;
@@ -29,6 +30,7 @@ import feign.form.FormEncoder;
 import feign.form.MultipartFormContentProcessor;
 
 import lombok.val;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -63,9 +65,9 @@ public class SpringFormEncoder extends FormEncoder {
   public void encode (Object object, Type bodyType, RequestTemplate template) throws EncodeException {
     if (bodyType.equals(MultipartFile[].class)) {
       val files = (MultipartFile[]) object;
-      val data = new HashMap<String, Object>(files.length, 1.F);
+      val data = new LinkedMultiValueMap<String, Object>();
       for (val file : files) {
-        data.put(file.getName(), file);
+        data.computeIfAbsent(file.getName(), name -> new ArrayList<>()).add(file);
       }
       super.encode(data, MAP_STRING_WILDCARD, template);
     } else if (bodyType.equals(MultipartFile.class)) {


### PR DESCRIPTION
In such situation the field name of multipart is always same, but files in the sending payload are more than one. Using standard HashMap causes, that it's impossible to send more files on same field name. I propose to use here MultiValueMap.

My defined API in spring is:
```
    @PostMapping(
            path = "/send-documents",
            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
    )
    ResponseResult sendDocuments(
            @RequestPart(name = "documents") MultipartFile[] documents);
```
When I create feign client with this and put more than one multipart files, I get only one document (last added). MultipartFile contains name (which is used as a field name - here _documents_) and originalName, which is the original name of the file. If I use another name, than _documents_, than spring controller doesn't get such element in the table (what's rather expected behavior).