### PR TITLE
Add EmptyCollectionWriter for MultipartFormContentProcessor

### DIFF
--- a/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
+++ b/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
@@ -33,6 +33,7 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.form.multipart.ByteArrayWriter;
 import feign.form.multipart.DelegateWriter;
+import feign.form.multipart.EmptyCollectionWriter;
 import feign.form.multipart.FormDataWriter;
 import feign.form.multipart.ManyFilesWriter;
 import feign.form.multipart.ManyParametersWriter;
@@ -41,13 +42,13 @@ import feign.form.multipart.PojoWriter;
 import feign.form.multipart.SingleFileWriter;
 import feign.form.multipart.SingleParameterWriter;
 import feign.form.multipart.Writer;
-
 import lombok.experimental.FieldDefaults;
 import lombok.val;
 
 /**
  *
  * @author Artem Labazin
+ * @author Darren Foong
  */
 @FieldDefaults(level = PRIVATE, makeFinal = true)
 public class MultipartFormContentProcessor implements ContentProcessor {
@@ -63,6 +64,7 @@ public class MultipartFormContentProcessor implements ContentProcessor {
    */
   public MultipartFormContentProcessor (Encoder delegate) {
     writers = new LinkedList<Writer>();
+    addWriter(new EmptyCollectionWriter());
     addWriter(new ByteArrayWriter());
     addWriter(new FormDataWriter());
     addWriter(new SingleFileWriter());

--- a/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
+++ b/feign-form/src/main/java/feign/form/MultipartFormContentProcessor.java
@@ -42,6 +42,7 @@ import feign.form.multipart.PojoWriter;
 import feign.form.multipart.SingleFileWriter;
 import feign.form.multipart.SingleParameterWriter;
 import feign.form.multipart.Writer;
+
 import lombok.experimental.FieldDefaults;
 import lombok.val;
 

--- a/feign-form/src/main/java/feign/form/multipart/EmptyCollectionWriter.java
+++ b/feign-form/src/main/java/feign/form/multipart/EmptyCollectionWriter.java
@@ -1,0 +1,20 @@
+package feign.form.multipart;
+
+import java.util.Collection;
+
+import feign.codec.EncodeException;
+
+/**
+ *
+ * @author Darren Foong
+ */
+public class EmptyCollectionWriter implements Writer {
+
+  @Override
+  public boolean isApplicable(Object value) {
+    return value instanceof Collection && ((Collection) value).isEmpty();
+  }
+
+  @Override
+  public void write(Output output, String boundary, String key, Object value) throws EncodeException {}
+}

--- a/feign-form/src/main/java/feign/form/multipart/EmptyCollectionWriter.java
+++ b/feign-form/src/main/java/feign/form/multipart/EmptyCollectionWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feign.form.multipart;
 
 import java.util.Collection;
@@ -11,10 +27,12 @@ import feign.codec.EncodeException;
 public class EmptyCollectionWriter implements Writer {
 
   @Override
-  public boolean isApplicable(Object value) {
+  public boolean isApplicable (Object value) {
     return value instanceof Collection && ((Collection) value).isEmpty();
   }
 
   @Override
-  public void write(Output output, String boundary, String key, Object value) throws EncodeException {}
+  public void write (Output output, String boundary, String key, Object value) throws EncodeException {
+    // no-op
+  }
 }


### PR DESCRIPTION
This PR adds an `EmptyCollectionWriter` to `MultipartFormContentProcessor` in `SpringFormEncoder`. This `Writer` is a no-op.

This is related to https://github.com/spring-cloud/spring-cloud-openfeign/pull/352. Although the problem could have been fixed in spring-cloud-openfeign, it was agreed that doing it upstream here would be better.

In `spring-cloud-openfeign`, `SpringFormEncoder` is a "delegate" of `SpringEncoder`, while in this repository (feign-form-spring's unit tests), (an older version of) `SpringEncoder` is a delegate of `SpringFormEncoder`. What this means is that the unit tests in feign-form-spring do not exactly reflect the actual use in spring-cloud-openfeign, so it is not meaningful to add a unit test in this PR as it would pass even without the `EmptyCollectionWriter`.