### PR TITLE
refactor: Delete `isFinal` , `isStatic` to support recored

### DIFF
--- a/feign-form/src/main/java/feign/form/util/PojoUtil.java
+++ b/feign-form/src/main/java/feign/form/util/PojoUtil.java
@@ -62,10 +62,6 @@ public final class PojoUtil {
     val type = object.getClass();
     val setAccessibleAction = new SetAccessibleAction();
     for (val field : type.getDeclaredFields()) {
-      val modifiers = field.getModifiers();
-      if (isFinal(modifiers) || isStatic(modifiers)) {
-        continue;
-      }
       setAccessibleAction.setField(field);
       AccessController.doPrivileged(setAccessibleAction);
 


### PR DESCRIPTION
#105 
@OlgaMaciaszek

```java
val modifiers = field.getModifiers();
      if (isFinal(modifiers) || isStatic(modifiers)) {
        continue;
      }
```
This code causes the recored dto to not work correctly when used in Java 17 and later versions.
Removing that code will not cause any problems.

